### PR TITLE
feat: convert pug class literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ In addition, if you are using the pug template, the writing method is exactly th
 
 In pug templates, it's possible to convert class literals to module classes.
 
-To enable that, set `pugClassLiterals: true` in plugin options:
+To enable that, set `pugClassLiterals: true` in plugin options:  
+
+When you set it to `true`, the class name priority is as follows: `class` < `:class` < `class literals` < `cls` < `:cls`
 
 ```js
 // vite.config.js

--- a/README.md
+++ b/README.md
@@ -119,7 +119,39 @@ In addition, if you are using the pug template, the writing method is exactly th
 > - The plugin will only find the first style tag that uses module and then use its name, which defaults to $style. In fact, setting a custom name such as `<style module="moduleName">` does not make sense for this plugin. 
 > - The plugin supports a variety of class name writing, although the writing is not very standardized.
 
+### Pug class literals
 
+In pug templates, it's possible to convert class literals to module classes.
+
+To enable that, set `pugClassLiterals: true` in plugin options:
+
+```js
+// vite.config.js
+import vueCssModule from 'vite-plugin-vue-css-module'
+export default defineConfig({
+  plugins: [
+    vueCssModule({
+      // Disabled by default.
+      pugClassLiterals: true
+    }), 
+    vue()
+  ],
+})
+```
+
+Then:
+
+```html
+<template lang="pug">
+.red This is red.
+div(cls="red") This is red.
+div(class="red") This is not red.
+</template>
+
+<style module>
+.red { color: red; }
+</style>
+```
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-vue-css-module",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-vue-css-module",
-      "version": "1.2.3",
+      "version": "1.3.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-typescript": "^11.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-vue-css-module",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "description": "css-module syntactic sugar for vue3",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { isLegalVariate } from './utils/tool'
 export default function vueCssModule(userOptions: Partial<PluginOptions> = {}): Plugin {
   const options = {
     attrName: 'cls', // 默认属性名
+    pugClassLiterals: false,
     ...userOptions
   }
   return {
@@ -36,7 +37,7 @@ export default function vueCssModule(userOptions: Partial<PluginOptions> = {}): 
             const langOffset = [langProps.loc.start.offset, langProps.loc.end.offset]
             // 删除 <template lang="pug"> 中的 lang="pug"
             s.update(langOffset[0], langOffset[1], '')
-            const result = parsePug(templateContent, options.attrName, cssModuleName)
+            const result = parsePug(templateContent, options, cssModuleName)
             // 将pug模板中的属性为 attrName 的值转为 cssModule写法，转为html模板
             s.update(templateOffset[0], templateOffset[1], result)
             return {

--- a/src/utils/parsePug.ts
+++ b/src/utils/parsePug.ts
@@ -74,6 +74,65 @@ export function parsePug(source: string, options: PluginOptions, cssModuleName: 
             }
         }
       })
+
+      if (attrNameNodes.length) {
+        const attrNameArr = transformString2Array(
+          attrNameNodes.map((node) => getPugVal(node.val)).join(' ')
+        )
+        if (attrNameArr.length) {
+          // :class
+          if (bindClassNode) {
+            let result: string
+            const bindClassContent = transform2SingleQuotes(getPugVal(bindClassNode.val))
+            // :class="{}"  :class='{}'
+            if (isObjectExp(bindClassContent)) {
+              // 获取{}中间的内容
+              let objectContent = getObjectOrArrayExpressionContent(bindClassContent)
+              /** fix: :class="{}" 和 :class="[]" 报错 */
+              if (objectContent) {
+                objectContent += ','
+              }
+              result = `"{${objectContent}${attrNameArr
+                .map((cls) => `[${cssModuleName}['${cls}']]:true`)
+                .join(',')}}"`
+            }
+            // :class="[]" :class='[]'
+            else if (isArrayExp(bindClassContent)) {
+              const arrayContent = getObjectOrArrayExpressionContent(bindClassContent)
+              result = `"[${arrayContent}, ${attrNameArr
+                .map((cls) => `${cssModuleName}['${cls}']`)
+                .join(',')}]"`
+            }
+            // :class="type" :class='type === "add" && "red"' :class="type === 'add' ? 'red' : 'green'"
+            else {
+              result = `"[${bindClassContent},${attrNameArr
+                .map((cls) => `${cssModuleName}['${cls}']`)
+                .join(',')}]"`
+            }
+            // 修改 :class的值
+            bindClassNode.val = result
+          }
+          // 只存在 或 不存在 class
+          else {
+            // Convert the first class attribute to :class.
+            const attrNameNode = attrNameNodes.shift()!
+            attrNameNode.mustEscape = true
+            attrNameNode.name = `:class`
+            attrNameNode.val = `"[${attrNameArr
+              .map((cls) => `${cssModuleName}['${cls}']`)
+              .join(',')}]"`
+
+            /**
+             * fix: Duplicate :class
+             */
+            bindClassNode = attrNameNode;
+          }
+        }
+        // 删除 attrName 属性
+        if (attrNameNodes.length) {
+          node.attrs = node.attrs.filter((attr) => !attrNameNodes.includes(attr))
+        }
+      }
       // 如果 attrName = cls, 且 :cls="" 存在
       if (bindAttrNameNode) {
         const bindAttrNameContent = transform2SingleQuotes(getPugVal(bindAttrNameNode.val))
@@ -155,60 +214,6 @@ export function parsePug(source: string, options: PluginOptions, cssModuleName: 
           } else {
             bindAttrNameNode.val = `"[${bindAttrNameContent2CssModuleNameStr}]"`
           }
-        }
-      }
-      if (attrNameNodes.length) {
-        const attrNameArr = transformString2Array(
-          attrNameNodes.map((node) => getPugVal(node.val)).join(' ')
-        )
-        // cls 为空时，直接删除属性
-        if (attrNameArr.length) {
-          // :class
-          if (bindClassNode) {
-            let result: string
-            const bindClassContent = transform2SingleQuotes(getPugVal(bindClassNode.val))
-            // :class="{}"  :class='{}'
-            if (isObjectExp(bindClassContent)) {
-              // 获取{}中间的内容
-              let objectContent = getObjectOrArrayExpressionContent(bindClassContent)
-              /** fix: :class="{}" 和 :class="[]" 报错 */
-              if (objectContent) {
-                objectContent += ','
-              }
-              result = `"{${objectContent}${attrNameArr
-                .map((cls) => `[${cssModuleName}['${cls}']]:true`)
-                .join(',')}}"`
-            }
-            // :class="[]" :class='[]'
-            else if (isArrayExp(bindClassContent)) {
-              const arrayContent = getObjectOrArrayExpressionContent(bindClassContent)
-              result = `"[${arrayContent}, ${attrNameArr
-                .map((cls) => `${cssModuleName}['${cls}']`)
-                .join(',')}]"`
-            }
-            // :class="type" :class='type === "add" && "red"' :class="type === 'add' ? 'red' : 'green'"
-            else {
-              result = `"[${bindClassContent},${attrNameArr
-                .map((cls) => `${cssModuleName}['${cls}']`)
-                .join(',')}]"`
-            }
-            // 修改 :class的值
-            bindClassNode.val = result
-          }
-          // 只存在 或 不存在 class
-          else {
-            // Convert the first class attribute to :class.
-            const attrNameNode = attrNameNodes.shift()!
-            attrNameNode.mustEscape = true
-            attrNameNode.name = `:class`
-            attrNameNode.val = `"[${attrNameArr
-              .map((cls) => `${cssModuleName}['${cls}']`)
-              .join(',')}]"`
-          }
-        }
-        // 删除 attrName 属性
-        if (attrNameNodes.length) {
-          node.attrs = node.attrs.filter((attr) => !attrNameNodes.includes(attr))
         }
       }
     }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,3 +1,6 @@
 export interface PluginOptions {
+  /** Attribute name for module classes. Default is "cls". */
   attrName: string
+  /** Whether to convert pug class literals. Default is false. */
+  pugClassLiterals: boolean
 }

--- a/test/pug-class-literal.spec.ts
+++ b/test/pug-class-literal.spec.ts
@@ -18,4 +18,9 @@ describe('pug class literal', () => {
       `class="red yellow" :class="[$style['wrap1'], $style['wrap2'], $style['wrap3'], $style['wrap4']]"`
     )
   })
+  test('class literals, module classes, normal classes, bind classes: class < :class < class literals < cls < :cls', () => {
+    expect(`.wrap1.wrap2(class="red yellow" cls="wrap3" :class="[type]" :cls="[wrap4]")`).toBePugCssModule(
+      `class="red yellow" :class="[type, $style['wrap1'], $style['wrap2'], $style['wrap3'], $style[wrap4]]"`
+    )
+  })
 })

--- a/test/pug-class-literal.spec.ts
+++ b/test/pug-class-literal.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest'
+
+describe('pug class literal', () => {
+  test('class literal', () => {
+    expect(`.wrap`).toBePugCssModule(`:class="[$style['wrap']]"`)
+  })
+  test('multiple class literals', () => {
+    expect(`.wrap1.wrap2`).toBePugCssModule(`:class="[$style['wrap1'], $style['wrap2']]"`)
+  })
+  test('class literal and normal class', () => {
+    expect(`.wrap(class="normal")`).toBePugCssModule(`class="normal" :class="[$style['wrap']]"`)
+  })
+  test('class literal and module class', () => {
+    expect(`.wrap1(cls="wrap2")`).toBePugCssModule(`:class="[$style['wrap1'], $style['wrap2']]"`)
+  })
+  test('class literals, module classes and normal classes', () => {
+    expect(`.wrap1.wrap2(class="red yellow" cls="wrap3 wrap4")`).toBePugCssModule(
+      `class="red yellow" :class="[$style['wrap1'], $style['wrap2'], $style['wrap3'], $style['wrap4']]"`
+    )
+  })
+})

--- a/test/pug.spec.ts
+++ b/test/pug.spec.ts
@@ -7,9 +7,26 @@ describe('pug string', () => {
   test('multiple module classes', () => {
     expect(`div(cls="wrap1 wrap2")`).toBePugCssModule(`:class="[$style['wrap1'], $style['wrap2']]"`)
   })
-  test('多个', () => {
+  test('multiple module classes and multiple normal classes', () => {
     expect(`div(class="red yellow" cls="green red")`).toBePugCssModule(
-      `class="red yellow":class="[$style['green'], $style['red']]"`
+      `class="red yellow" :class="[$style['green'], $style['red']]"`
     )
   })
+  test('normal classes, module classes and bind classes: class < :class < cls', () => {
+    expect(`div(class="red yellow" cls="wrap" :class="[type]")`).toBePugCssModule(
+      `class="red yellow" :class="[type, $style['wrap']]"`
+    )
+  })
+  test('normal classes, bind module classes and bind classes: class < :class < :cls', () => {
+    expect(`div(class="red yellow" :cls="{wrap: true}" :class="[type]")`).toBePugCssModule(
+      `class="red yellow" :class="{ [type]: type, [$style['wrap']]: true}"`
+    )
+  })
+
+  test('normal classes, module classes, bind module classes and bind classes: class < :class < cls < :cls', () => {
+    expect(`div(class="red yellow" cls="green" :cls="{wrap: true}" :class="[type]")`).toBePugCssModule(
+      `class="red yellow" :class="{ [type]: type, [$style['green']]: $style['green'], [$style['wrap']]: true}"`
+    )
+  })
+
 })

--- a/test/pug.spec.ts
+++ b/test/pug.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'vitest'
+
+describe('pug string', () => {
+  test('single module class', () => {
+    expect(`div(cls="wrap")`).toBePugCssModule(`:class="[$style['wrap']]"`)
+  })
+  test('multiple module classes', () => {
+    expect(`div(cls="wrap1 wrap2")`).toBePugCssModule(`:class="[$style['wrap1'], $style['wrap2']]"`)
+  })
+  test('多个', () => {
+    expect(`div(class="red yellow" cls="green red")`).toBePugCssModule(
+      `class="red yellow":class="[$style['green'], $style['red']]"`
+    )
+  })
+})

--- a/test/utils/setup-files.ts
+++ b/test/utils/setup-files.ts
@@ -4,18 +4,24 @@ import { assembleVue, removeNonCoreCode, removeBlank, plugin } from './utils'
 // 扩展 .toBeCssModule
 expect.extend({
   toBeCssModule: async (received: string, expected: string) => {
-    const originVue = assembleVue(received)
-    const { code: resultVue } = await (plugin as any).transform(originVue, 'toBeCssModule.vue')
-    const resultCore = removeNonCoreCode(resultVue)
-    const expectedCore = removeBlank(expected)
-    return {
-      pass: resultCore === expectedCore,
-      message: () => `
-        \n         full result 》 ${resultVue}
-        \n            expected 》 ${expected}
-        \n (no space) expected 》 ${expectedCore}
-        \n   (no space) result 》 ${resultCore}
-      `
-    }
+    return testVue(assembleVue('html', `<div ${received}></div>`), expected)
+  },
+  toBePugCssModule: async (received: string, expected: string) => {
+    return testVue(assembleVue('pug', received), expected)
   }
 })
+
+async function testVue(originVue: string, expected: string) {
+  const { code: resultVue } = await (plugin as any).transform(originVue, 'toBeCssModule.vue')
+  const resultCore = removeNonCoreCode(resultVue)
+  const expectedCore = removeBlank(expected)
+  return {
+    pass: resultCore === expectedCore,
+    message: () => `
+      \n         full result 》 ${resultVue}
+      \n            expected 》 ${expected}
+      \n (no space) expected 》 ${expectedCore}
+      \n   (no space) result 》 ${resultCore}
+    `
+  }
+}

--- a/test/utils/utils.ts
+++ b/test/utils/utils.ts
@@ -2,7 +2,8 @@ import { readFileSync, writeFileSync } from 'fs'
 import vueCssModule from '@/index'
 
 export const plugin = vueCssModule({
-  attrName: 'cls'
+  attrName: 'cls',
+  pugClassLiterals: true
 })
 
 /**
@@ -31,8 +32,8 @@ function assembleStyle(module?: string) {
  * @param module cssModule模块名
  * @returns vue组件
  */
-export function assembleVue(code: string, module?: string) {
-  let template = `<template><div ${code}></div></template>`
+export function assembleVue(lang: 'html' | 'pug', code: string, module?: string) {
+  let template = `<template lang="${lang}">${code}</template>`
   let style = assembleStyle(module)
   return template + style
 }
@@ -54,5 +55,7 @@ export function removeBlank(code: string) {
  */
 export function removeNonCoreCode(code: string, module?: string) {
   let style = assembleStyle(module)
-  return removeBlank(code.replace('<template><div ', '').replace('></div></template>' + style, ''))
+  return removeBlank(
+    code.replace(/<template.*?><div /, '').replace('></div></template>' + style, '')
+  )
 }

--- a/vitest.d.ts
+++ b/vitest.d.ts
@@ -2,6 +2,7 @@ import type { Assertion, AsymmetricMatchersContaining } from 'vitest'
 
 interface CustomMatchers<R = unknown> {
   toBeCssModule(string): R
+  toBePugCssModule(string): R
 }
 
 declare module 'vitest' {


### PR DESCRIPTION
Following my suggestion https://github.com/HJinPeng/vite-plugin-vue-css-module/issues/2#issuecomment-1672901425, I came up with a PR: convert pug class literals to module classes:

```vue
<template lang="pug">
.red This is red.
div(cls="red") This is red.
div(class="red") This is not red.
</template>

<style module>
.red { color: red; }
</style>
```

This is backwards compatible and disabled by default.