### PR TITLE
Remove extra tsup externals

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,5 +6,12 @@ export default defineConfig({
   sourcemap: true,
   dts: true,
   clean: true,
-  external: ['vite', 'vue', 'pug-parser', 'pug-lexer', 'pug-walk', 'pug-runtime/wrap.js', 'pug-code-gen', 'vue/compiler-sfc', 'magic-string']
+  // Remove those once https://github.com/egoist/tsup/issues/1099 is fixed.
+  external: [
+    'pug-code-gen',
+    'pug-lexer',
+    'pug-parser',
+    'pug-runtime',
+    'pug-walk',
+  ],
 })


### PR DESCRIPTION
tsup automatically marks deps and peerDeps as external, they should not be repeated in the externals list. It doesn't mark optionalDeps as external by default, so they (and only they at the moment) should be kept in the list.

This PR cleans the externals list, sorts the remaining items, and leaves the comment saying that the list should be completely removed if/when tsup will mark optionalDeps as external on its own.