### PR TITLE
Use MagicString provided by Vue

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,9 +60,6 @@
   },
   "homepage": "https://github.com/HJinPeng/vite-plugin-vue-css-module#readme",
   "license": "MIT",
-  "dependencies": {
-    "magic-string": "^0.30.5"
-  },
   "devDependencies": {
     "eslint": "^8.44.0",
     "prettier": "^3.0.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from 'vite'
 import type { PluginOptions } from './utils/types'
-import MagicString from 'magic-string'
+import { MagicString } from 'vue/compiler-sfc'
 import { parseVue } from './utils/parseVue'
 import { parseHtml } from './utils/parseHtml'
 import { parsePug } from './utils/parsePug'

--- a/src/utils/parseHtml.ts
+++ b/src/utils/parseHtml.ts
@@ -1,5 +1,5 @@
 import type { AttributeNode, DirectiveNode, TemplateChildNode } from '@vue/compiler-core'
-import MagicString from 'magic-string'
+import { MagicString } from 'vue/compiler-sfc'
 import {
   trimString,
   isObjectExp,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,5 +6,5 @@ export default defineConfig({
   sourcemap: true,
   dts: true,
   clean: true,
-  external: ['vite', 'vue', 'pug-parser', 'pug-lexer', 'pug-walk', 'pug-runtime/wrap.js', 'pug-code-gen', 'vue/compiler-sfc', 'magic-string']
+  external: ['vite', 'vue', 'pug-parser', 'pug-lexer', 'pug-walk', 'pug-runtime/wrap.js', 'pug-code-gen', 'vue/compiler-sfc']
 })


### PR DESCRIPTION
There is no need to require external magic string as it's provided (re-exported) by Vue itself. This change reduces burden on user's node_modules.

**Heads up**: if this is merged with #10, `pnpm-lock.yaml` should be regenerated.