### PR TITLE
Fix tests to await custom async matchers

### DIFF
--- a/test/array-array.spec.ts
+++ b/test/array-array.spec.ts
@@ -1,20 +1,20 @@
 import { describe, expect, test } from 'vitest'
 
 describe('cls数组，class数组', () => {
-  test('表达式1', () => {
-    expect(
+  test('表达式1', async () => {
+    await expect(
       `:class="[type]" :cls="[item1, 'item2', true && 'item' + '3', item4 === 'item4' ? item5 : 'item6']"`
     ).toBeCssModule(
       `:class="[type, $style[item1], $style['item2'], $style[true&&'item'+'3'], $style[item4 === 'item4' ? item5 : 'item6']]"`
     )
   })
-  test('表达式2', () => {
-    expect(`:class="[type]" :cls="[item1, [item2, true && 'item3'], item4]"`).toBeCssModule(
+  test('表达式2', async () => {
+    await expect(`:class="[type]" :cls="[item1, [item2, true && 'item3'], item4]"`).toBeCssModule(
       `:class="[type, $style[item1], [$style[item2], $style[true && 'item3']], $style[item4]]"`
     )
   })
-  test('表达式3', () => {
-    expect(
+  test('表达式3', async () => {
+    await expect(
       `:class="[type]" :cls="[item1, [item2], { item3: true }, [{item4: true}]]"`
     ).toBeCssModule(
       `:class="[type, $style[item1], [$style[item2]], {[$style['item3']]: true}, [{[$style['item4']]: true}]]"`

--- a/test/array-expression.spec.ts
+++ b/test/array-expression.spec.ts
@@ -1,20 +1,20 @@
 import { describe, expect, test } from 'vitest'
 
 describe('cls数组，class表达式', () => {
-  test('表达式1', () => {
-    expect(
+  test('表达式1', async () => {
+    await expect(
       `:class="type" :cls="[item1, 'item2', true && 'item' + '3', item4 === 'item4' ? item5 : 'item6']"`
     ).toBeCssModule(
       `:class="[type, $style[item1], $style['item2'], $style[true && 'item' + '3'], $style[item4 === 'item4' ? item5 : 'item6']]"`
     )
   })
-  test('表达式2', () => {
-    expect(`:class="true && type" :cls="[item1, [item2, true && 'item3'], item4]"`).toBeCssModule(
+  test('表达式2', async () => {
+    await expect(`:class="true && type" :cls="[item1, [item2, true && 'item3'], item4]"`).toBeCssModule(
       `:class="[true && type, $style[item1], [$style[item2], $style[true && 'item3']], $style[item4]]"`
     )
   })
-  test('表达式3', () => {
-    expect(
+  test('表达式3', async () => {
+    await expect(
       `:class="1 + 1 === 2 ? type1 : type2" :cls="[item1, [item2], { item3: true }]"`
     ).toBeCssModule(
       `:class="[1 + 1 === 2 ? type1 : type2, $style[item1], [$style[item2]], {[$style['item3']]: true}]"`

--- a/test/array-none.spec.ts
+++ b/test/array-none.spec.ts
@@ -1,20 +1,20 @@
 import { describe, expect, test } from 'vitest'
 
 describe('cls数组，class空', () => {
-  test('表达式1', () => {
-    expect(
+  test('表达式1', async () => {
+    await expect(
       `:cls="[item1, 'item2', true && 'item' + '3', item4 === 'item4' ? item5 : 'item6']"`
     ).toBeCssModule(
       `:class="[$style[item1], $style['item2'], $style[true && 'item' + '3'], $style[item4 === 'item4' ? item5 : 'item6']]"`
     )
   })
-  test('表达式2', () => {
-    expect(`:cls="[item1, [item2, true && 'item3'], item4]"`).toBeCssModule(
+  test('表达式2', async () => {
+    await expect(`:cls="[item1, [item2, true && 'item3'], item4]"`).toBeCssModule(
       `:class="[$style[item1], [$style[item2], $style[true && 'item3']], $style[item4]]"`
     )
   })
-  test('表达式3', () => {
-    expect(`:cls="[item1, [item2], { item3: true }]"`).toBeCssModule(
+  test('表达式3', async () => {
+    await expect(`:cls="[item1, [item2], { item3: true }]"`).toBeCssModule(
       `:class="[$style[item1], [$style[item2]], {[$style['item3']]: true}]"`
     )
   })

--- a/test/array-object.spec.ts
+++ b/test/array-object.spec.ts
@@ -1,22 +1,22 @@
 import { describe, expect, test } from 'vitest'
 
 describe('cls数组，class对象', () => {
-  test('表达式1', () => {
-    expect(
+  test('表达式1', async () => {
+    await expect(
       `:class="{type}" :cls="[item1, 'item2', true && 'item' + '3', item4 === 'item4' ? item5 : 'item6']"`
     ).toBeCssModule(
       `:class="{type, [$style[item1]]: $style[item1], [$style['item2']]: $style['item2'], [$style[true && 'item'+'3']]: $style[true && 'item'+'3'], [$style[item4 === 'item4' ? item5 : 'item6']]: $style[item4 === 'item4' ? item5 : 'item6']}"`
     )
   })
-  test('表达式2', () => {
-    expect(
+  test('表达式2', async () => {
+    await expect(
       `:class='{type: true}' :cls="[[item0, item1], [item2, true && 'item33'], item4]"`
     ).toBeCssModule(
       `:class='{type:true, [$style[item0]]: $style[item0], [$style[item1]]: $style[item1], [$style[item2]]: $style[item2], [$style[true && "item33"]]: $style[true && "item33"], [$style[item4]]: $style[item4]}'`
     )
   })
-  test('表达式3', () => {
-    expect(
+  test('表达式3', async () => {
+    await expect(
       `:class="{[type]: true}" :cls='["item1", [item2, item3, {item4: true}], { item5: true }]'`
     ).toBeCssModule(
       `:class="{[type]: true, [$style['item1']]: $style['item1'], [$style[item2]]: $style[item2], [$style[item3]]: $style[item3], [$style['item4']]: true, [$style['item5']]: true}"`

--- a/test/array-string.spec.ts
+++ b/test/array-string.spec.ts
@@ -1,20 +1,20 @@
 import { describe, expect, test } from 'vitest'
 
 describe('cls数组，class字符串', () => {
-  test('表达式1', () => {
-    expect(
+  test('表达式1', async () => {
+    await expect(
       `class="type1 type2" :cls="[item1, 'item2', true && 'item' + '3', item4 === 'item4' ? item5 : 'item6']"`
     ).toBeCssModule(
       `class="type1 type2" :class="[$style[item1], $style['item2'], $style[true && 'item' + '3'], $style[item4 === 'item4' ? item5 : 'item6']]"`
     )
   })
-  test('表达式2', () => {
-    expect(`class="type1 type2" :cls="[item1, [item2, true && 'item3'], item4]"`).toBeCssModule(
+  test('表达式2', async () => {
+    await expect(`class="type1 type2" :cls="[item1, [item2, true && 'item3'], item4]"`).toBeCssModule(
       `class="type1 type2" :class="[$style[item1], [$style[item2], $style[true && 'item3']], $style[item4]]"`
     )
   })
-  test('表达式3', () => {
-    expect(`class="type1 type2" :cls="[item1, [item2], { item3: true }]"`).toBeCssModule(
+  test('表达式3', async () => {
+    await expect(`class="type1 type2" :cls="[item1, [item2], { item3: true }]"`).toBeCssModule(
       `class="type1 type2" :class="[$style[item1], [$style[item2]], {[$style['item3']]: true}]"`
     )
   })

--- a/test/expression-array.spec.ts
+++ b/test/expression-array.spec.ts
@@ -1,21 +1,21 @@
 import { describe, expect, test } from 'vitest'
 
 describe('cls表达式，class数组', () => {
-  test('表达式1', () => {
-    expect(`:class="[wrap, 'wrap2']" :cls="wrap"`).toBeCssModule(
+  test('表达式1', async () => {
+    await expect(`:class="[wrap, 'wrap2']" :cls="wrap"`).toBeCssModule(
       `:class="[wrap, 'wrap2', $style[wrap]]"`
     )
   })
-  test('表达式2', () => {
-    expect(`:class="['wrap']" :cls="'wrap'"`).toBeCssModule(`:class="['wrap', $style['wrap']]"`)
+  test('表达式2', async () => {
+    await expect(`:class="['wrap']" :cls="'wrap'"`).toBeCssModule(`:class="['wrap', $style['wrap']]"`)
   })
-  test('表达式3', () => {
-    expect(`:class="[true && type]" :cls="true && type"`).toBeCssModule(
+  test('表达式3', async () => {
+    await expect(`:class="[true && type]" :cls="true && type"`).toBeCssModule(
       `:class="[true && type, $style[true && type]]"`
     )
   })
-  test('表达式4', () => {
-    expect(
+  test('表达式4', async () => {
+    await expect(
       `:class="[type === 'add' ? type + '--active' : type]" :cls="type === 'add' ? type + '--active' : type"`
     ).toBeCssModule(
       `:class="[type === 'add' ? type + '--active' : type, $style[type === 'add' ? type + '--active' : type]]"`

--- a/test/expression-expression.spec.ts
+++ b/test/expression-expression.spec.ts
@@ -1,19 +1,19 @@
 import { describe, expect, test } from 'vitest'
 
 describe('cls表达式，class表达式', () => {
-  test('表达式1', () => {
-    expect(`:class="wrap" :cls="wrap"`).toBeCssModule(`:class="[wrap, $style[wrap]]"`)
+  test('表达式1', async () => {
+    await expect(`:class="wrap" :cls="wrap"`).toBeCssModule(`:class="[wrap, $style[wrap]]"`)
   })
-  test('表达式2', () => {
-    expect(`:class="'wrap'" :cls="'wrap'"`).toBeCssModule(`:class="['wrap', $style['wrap']]"`)
+  test('表达式2', async () => {
+    await expect(`:class="'wrap'" :cls="'wrap'"`).toBeCssModule(`:class="['wrap', $style['wrap']]"`)
   })
-  test('表达式3', () => {
-    expect(`:class="true && type" :cls="true && type"`).toBeCssModule(
+  test('表达式3', async () => {
+    await expect(`:class="true && type" :cls="true && type"`).toBeCssModule(
       `:class="[true && type, $style[true && type]]"`
     )
   })
-  test('表达式4', () => {
-    expect(
+  test('表达式4', async () => {
+    await expect(
       `:class="type === 'add' ? type + '--active' : type" :cls="type === 'add' ? type + '--active' : type"`
     ).toBeCssModule(
       `:class="[type === 'add' ? type + '--active' : type, $style[type === 'add' ? type + '--active' : type]]"`

--- a/test/expression-none.spec.ts
+++ b/test/expression-none.spec.ts
@@ -1,17 +1,17 @@
 import { describe, expect, test } from 'vitest'
 
 describe('cls表达式，class空', () => {
-  test('表达式1', () => {
-    expect(`:cls="wrap"`).toBeCssModule(`:class="[$style[wrap]]"`)
+  test('表达式1', async () => {
+    await expect(`:cls="wrap"`).toBeCssModule(`:class="[$style[wrap]]"`)
   })
-  test('表达式2', () => {
-    expect(`:cls="'wrap'"`).toBeCssModule(`:class="[$style['wrap']]"`)
+  test('表达式2', async () => {
+    await expect(`:cls="'wrap'"`).toBeCssModule(`:class="[$style['wrap']]"`)
   })
-  test('表达式3', () => {
-    expect(`:cls="true && type"`).toBeCssModule(`:class="[$style[true && type]]"`)
+  test('表达式3', async () => {
+    await expect(`:cls="true && type"`).toBeCssModule(`:class="[$style[true && type]]"`)
   })
-  test('表达式4', () => {
-    expect(`:cls="type === 'add' ? type + '--active' : type"`).toBeCssModule(
+  test('表达式4', async () => {
+    await expect(`:cls="type === 'add' ? type + '--active' : type"`).toBeCssModule(
       `:class="[$style[type === 'add' ? type + '--active' : type]]"`
     )
   })

--- a/test/expression-object.spec.ts
+++ b/test/expression-object.spec.ts
@@ -1,23 +1,23 @@
 import { describe, expect, test } from 'vitest'
 
 describe('cls表达式，class对象', () => {
-  test('表达式1', () => {
-    expect(`:class="{ type: true, item }" :cls="wrap"`).toBeCssModule(
+  test('表达式1', async () => {
+    await expect(`:class="{ type: true, item }" :cls="wrap"`).toBeCssModule(
       `:class="{ type: true, item, [$style[wrap]]: $style[wrap]}"`
     )
   })
-  test('表达式2', () => {
-    expect(`:class="{ type: true, item }" :cls="'wrap'"`).toBeCssModule(
+  test('表达式2', async () => {
+    await expect(`:class="{ type: true, item }" :cls="'wrap'"`).toBeCssModule(
       `:class="{ type: true, item, [$style['wrap']]: $style['wrap']}"`
     )
   })
-  test('表达式3', () => {
-    expect(`:class="{ type: true, item }" :cls="true && type"`).toBeCssModule(
+  test('表达式3', async () => {
+    await expect(`:class="{ type: true, item }" :cls="true && type"`).toBeCssModule(
       `:class="{ type: true, item, [$style[true && type]]: $style[true && type]}"`
     )
   })
-  test('表达式4', () => {
-    expect(
+  test('表达式4', async () => {
+    await expect(
       `:class="{ type: true, item }" :cls="type === 'add' ? type + '--active' : type"`
     ).toBeCssModule(
       `:class="{type: true, item, [$style[type ==='add' ? type + '--active' : type]]: $style[type === 'add' ? type + '--active' : type]}"`

--- a/test/expression-string.spec.ts
+++ b/test/expression-string.spec.ts
@@ -1,23 +1,23 @@
 import { describe, expect, test } from 'vitest'
 
 describe('cls表达式，class字符串', () => {
-  test('表达式1', () => {
-    expect(`class="type1 type2" :cls="wrap"`).toBeCssModule(
+  test('表达式1', async () => {
+    await expect(`class="type1 type2" :cls="wrap"`).toBeCssModule(
       `class="type1 type2" :class="[$style[wrap]]"`
     )
   })
-  test('表达式2', () => {
-    expect(`class="type1 type2" :cls="'wrap'"`).toBeCssModule(
+  test('表达式2', async () => {
+    await expect(`class="type1 type2" :cls="'wrap'"`).toBeCssModule(
       `class="type1 type2" :class="[$style['wrap']]"`
     )
   })
-  test('表达式3', () => {
-    expect(`class="type1 type2" :cls="true && type"`).toBeCssModule(
+  test('表达式3', async () => {
+    await expect(`class="type1 type2" :cls="true && type"`).toBeCssModule(
       `class="type1 type2" :class="[$style[true && type]]"`
     )
   })
-  test('表达式4', () => {
-    expect(`class="type1 type2" :cls="type === 'add' ? type + '--active' : type"`).toBeCssModule(
+  test('表达式4', async () => {
+    await expect(`class="type1 type2" :cls="type === 'add' ? type + '--active' : type"`).toBeCssModule(
       `class="type1 type2" :class="[$style[type === 'add' ? type + '--active' : type]]"`
     )
   })

--- a/test/object-array.spec.ts
+++ b/test/object-array.spec.ts
@@ -1,18 +1,18 @@
 import { describe, expect, test } from 'vitest'
 
 describe('cls对象，class数组', () => {
-  test('表达式1', () => {
-    expect(`:class="[type1, 'type2']" :cls="{item}"`).toBeCssModule(
+  test('表达式1', async () => {
+    await expect(`:class="[type1, 'type2']" :cls="{item}"`).toBeCssModule(
       `:class="{[type1]: type1, ['type2']: 'type2',[$style['item']]: item}"`
     )
   })
-  test('表达式2', () => {
-    expect(`:class="[type1, 'type2']" :cls="{ item: true, item2: false }"`).toBeCssModule(
+  test('表达式2', async () => {
+    await expect(`:class="[type1, 'type2']" :cls="{ item: true, item2: false }"`).toBeCssModule(
       `:class="{[type1]: type1, ['type2']: 'type2', [$style['item']]: true, [$style['item2']]: false}"`
     )
   })
-  test('表达式3', () => {
-    expect(`:class="[type1, 'type2']" :cls="{ [item]: true }"`).toBeCssModule(
+  test('表达式3', async () => {
+    await expect(`:class="[type1, 'type2']" :cls="{ [item]: true }"`).toBeCssModule(
       `:class="{[type1]: type1, ['type2']: 'type2', [$style[[item]]]: true}"`
     )
   })

--- a/test/object-expression.spec.ts
+++ b/test/object-expression.spec.ts
@@ -1,18 +1,18 @@
 import { describe, expect, test } from 'vitest'
 
 describe('cls对象，class表达式', () => {
-  test('表达式1', () => {
-    expect(`:class="type1" :cls="{item}"`).toBeCssModule(
+  test('表达式1', async () => {
+    await expect(`:class="type1" :cls="{item}"`).toBeCssModule(
       `:class="{[type1]: type1, [$style['item']]: item}"`
     )
   })
-  test('表达式2', () => {
-    expect(`:class="true && type1" :cls="{ item: true, item2: false }"`).toBeCssModule(
+  test('表达式2', async () => {
+    await expect(`:class="true && type1" :cls="{ item: true, item2: false }"`).toBeCssModule(
       `:class="{[true && type1]: true && type1, [$style['item']]: true, [$style['item2']]: false}"`
     )
   })
-  test('表达式3', () => {
-    expect(`:class="1 + 1 === 2 ? type1 : 'type2'" :cls="{ [item]: true }"`).toBeCssModule(
+  test('表达式3', async () => {
+    await expect(`:class="1 + 1 === 2 ? type1 : 'type2'" :cls="{ [item]: true }"`).toBeCssModule(
       `:class="{[1 + 1 === 2 ? type1 : 'type2']: 1 + 1 === 2 ? type1 : 'type2', [$style[[item]]]: true}"`
     )
   })

--- a/test/object-none.spec.ts
+++ b/test/object-none.spec.ts
@@ -1,15 +1,15 @@
 import { describe, expect, test } from 'vitest'
 
 describe('cls对象，class空', () => {
-  test('表达式1', () => {
-    expect(`:cls="{item}"`).toBeCssModule(`:class="{[$style['item']]: item}"`)
+  test('表达式1', async () => {
+    await expect(`:cls="{item}"`).toBeCssModule(`:class="{[$style['item']]: item}"`)
   })
-  test('表达式2', () => {
-    expect(`:cls="{ item: true, item2: false }"`).toBeCssModule(
+  test('表达式2', async () => {
+    await expect(`:cls="{ item: true, item2: false }"`).toBeCssModule(
       `:class="{[$style['item']]: true,[$style['item2']]: false}"`
     )
   })
-  test('表达式3', () => {
-    expect(`:cls="{ [item]: true }"`).toBeCssModule(`:class="{[$style[[item]]]: true}"`)
+  test('表达式3', async () => {
+    await expect(`:cls="{ [item]: true }"`).toBeCssModule(`:class="{[$style[[item]]]: true}"`)
   })
 })

--- a/test/object-object.spec.ts
+++ b/test/object-object.spec.ts
@@ -1,18 +1,18 @@
 import { describe, expect, test } from 'vitest'
 
 describe('cls对象，class对象', () => {
-  test('表达式1', () => {
-    expect(`:class="{type: type === 'add'}" :cls="{item}"`).toBeCssModule(
+  test('表达式1', async () => {
+    await expect(`:class="{type: type === 'add'}" :cls="{item}"`).toBeCssModule(
       `:class="{ type: type === 'add', [$style['item']]: item}"`
     )
   })
-  test('表达式2', () => {
-    expect(`:class="{type: type === 'add'}" :cls="{ item: true, item2: false }"`).toBeCssModule(
+  test('表达式2', async () => {
+    await expect(`:class="{type: type === 'add'}" :cls="{ item: true, item2: false }"`).toBeCssModule(
       `:class="{type: type === 'add', [$style['item']]: true,[$style['item2']]: false}"`
     )
   })
-  test('表达式3', () => {
-    expect(`:class="{type: type === 'add'}" :cls="{ [item]: true }"`).toBeCssModule(
+  test('表达式3', async () => {
+    await expect(`:class="{type: type === 'add'}" :cls="{ [item]: true }"`).toBeCssModule(
       `:class="{type: type === 'add', [$style[[item]]]: true}"`
     )
   })

--- a/test/object-string.spec.ts
+++ b/test/object-string.spec.ts
@@ -1,18 +1,18 @@
 import { describe, expect, test } from 'vitest'
 
 describe('cls对象，class字符串', () => {
-  test('表达式1', () => {
-    expect(`class="type1 type2" :cls="{item}"`).toBeCssModule(
+  test('表达式1', async () => {
+    await expect(`class="type1 type2" :cls="{item}"`).toBeCssModule(
       `class="type1 type2" :class="{[$style['item']]: item}"`
     )
   })
-  test('表达式2', () => {
-    expect(`class="type1 type2" :cls="{ item: true, item2: false }"`).toBeCssModule(
+  test('表达式2', async () => {
+    await expect(`class="type1 type2" :cls="{ item: true, item2: false }"`).toBeCssModule(
       `class="type1 type2" :class="{[$style['item']]: true, [$style['item2']]: false}"`
     )
   })
-  test('表达式3', () => {
-    expect(`class="type1 type2" :cls="{ [item]: true }"`).toBeCssModule(
+  test('表达式3', async () => {
+    await expect(`class="type1 type2" :cls="{ [item]: true }"`).toBeCssModule(
       `class="type1 type2" :class="{[$style[[item]]]: true}"`
     )
   })

--- a/test/pug-class-literal.spec.ts
+++ b/test/pug-class-literal.spec.ts
@@ -1,25 +1,25 @@
 import { describe, expect, test } from 'vitest'
 
 describe('pug class literal', () => {
-  test('class literal', () => {
-    expect(`.wrap`).toBePugCssModule(`:class="[$style['wrap']]"`)
+  test('class literal', async () => {
+    await expect(`.wrap`).toBePugCssModule(`:class="[$style['wrap']]"`)
   })
-  test('multiple class literals', () => {
-    expect(`.wrap1.wrap2`).toBePugCssModule(`:class="[$style['wrap1'], $style['wrap2']]"`)
+  test('multiple class literals', async () => {
+    await expect(`.wrap1.wrap2`).toBePugCssModule(`:class="[$style['wrap1'], $style['wrap2']]"`)
   })
-  test('class literal and normal class', () => {
-    expect(`.wrap(class="normal")`).toBePugCssModule(`class="normal" :class="[$style['wrap']]"`)
+  test('class literal and normal class', async () => {
+    await expect(`.wrap(class="normal")`).toBePugCssModule(`class="normal" :class="[$style['wrap']]"`)
   })
-  test('class literal and module class', () => {
-    expect(`.wrap1(cls="wrap2")`).toBePugCssModule(`:class="[$style['wrap1'], $style['wrap2']]"`)
+  test('class literal and module class', async () => {
+    await expect(`.wrap1(cls="wrap2")`).toBePugCssModule(`:class="[$style['wrap1'], $style['wrap2']]"`)
   })
-  test('class literals, module classes and normal classes', () => {
-    expect(`.wrap1.wrap2(class="red yellow" cls="wrap3 wrap4")`).toBePugCssModule(
+  test('class literals, module classes and normal classes', async () => {
+    await expect(`.wrap1.wrap2(class="red yellow" cls="wrap3 wrap4")`).toBePugCssModule(
       `class="red yellow" :class="[$style['wrap1'], $style['wrap2'], $style['wrap3'], $style['wrap4']]"`
     )
   })
-  test('class literals, module classes, normal classes, bind classes: class < :class < class literals < cls < :cls', () => {
-    expect(`.wrap1.wrap2(class="red yellow" cls="wrap3" :class="[type]" :cls="[wrap4]")`).toBePugCssModule(
+  test('class literals, module classes, normal classes, bind classes: class < :class < class literals < cls < :cls', async () => {
+    await expect(`.wrap1.wrap2(class="red yellow" cls="wrap3" :class="[type]" :cls="[wrap4]")`).toBePugCssModule(
       `class="red yellow" :class="[type, $style['wrap1'], $style['wrap2'], $style['wrap3'], $style[wrap4]]"`
     )
   })

--- a/test/pug.spec.ts
+++ b/test/pug.spec.ts
@@ -1,30 +1,30 @@
 import { describe, expect, test } from 'vitest'
 
 describe('pug string', () => {
-  test('single module class', () => {
-    expect(`div(cls="wrap")`).toBePugCssModule(`:class="[$style['wrap']]"`)
+  test('single module class', async () => {
+    await expect(`div(cls="wrap")`).toBePugCssModule(`:class="[$style['wrap']]"`)
   })
-  test('multiple module classes', () => {
-    expect(`div(cls="wrap1 wrap2")`).toBePugCssModule(`:class="[$style['wrap1'], $style['wrap2']]"`)
+  test('multiple module classes', async () => {
+    await expect(`div(cls="wrap1 wrap2")`).toBePugCssModule(`:class="[$style['wrap1'], $style['wrap2']]"`)
   })
-  test('multiple module classes and multiple normal classes', () => {
-    expect(`div(class="red yellow" cls="green red")`).toBePugCssModule(
+  test('multiple module classes and multiple normal classes', async () => {
+    await expect(`div(class="red yellow" cls="green red")`).toBePugCssModule(
       `class="red yellow" :class="[$style['green'], $style['red']]"`
     )
   })
-  test('normal classes, module classes and bind classes: class < :class < cls', () => {
-    expect(`div(class="red yellow" cls="wrap" :class="[type]")`).toBePugCssModule(
+  test('normal classes, module classes and bind classes: class < :class < cls', async () => {
+    await expect(`div(class="red yellow" cls="wrap" :class="[type]")`).toBePugCssModule(
       `class="red yellow" :class="[type, $style['wrap']]"`
     )
   })
-  test('normal classes, bind module classes and bind classes: class < :class < :cls', () => {
-    expect(`div(class="red yellow" :cls="{wrap: true}" :class="[type]")`).toBePugCssModule(
+  test('normal classes, bind module classes and bind classes: class < :class < :cls', async () => {
+    await expect(`div(class="red yellow" :cls="{wrap: true}" :class="[type]")`).toBePugCssModule(
       `class="red yellow" :class="{ [type]: type, [$style['wrap']]: true}"`
     )
   })
 
-  test('normal classes, module classes, bind module classes and bind classes: class < :class < cls < :cls', () => {
-    expect(`div(class="red yellow" cls="green" :cls="{wrap: true}" :class="[type]")`).toBePugCssModule(
+  test('normal classes, module classes, bind module classes and bind classes: class < :class < cls < :cls', async () => {
+    await expect(`div(class="red yellow" cls="green" :cls="{wrap: true}" :class="[type]")`).toBePugCssModule(
       `class="red yellow" :class="{ [type]: type, [$style['green']]: $style['green'], [$style['wrap']]: true}"`
     )
   })

--- a/test/special.spec.ts
+++ b/test/special.spec.ts
@@ -1,54 +1,54 @@
 import { describe, expect, test } from 'vitest'
 
 describe('特殊情况', () => {
-  test('空', () => {
-    expect(`cls=""`).toBeCssModule(``)
-    expect(`cls="  "`).toBeCssModule(``)
-    expect(`cls`).toBeCssModule(``)
-    expect(`:cls=""`).toBeCssModule(``)
-    expect(`:cls="[]"`).toBeCssModule(``)
-    expect(`:cls="{}"`).toBeCssModule(``)
+  test('空', async () => {
+    await expect(`cls=""`).toBeCssModule(``)
+    await expect(`cls="  "`).toBeCssModule(``)
+    await expect(`cls`).toBeCssModule(``)
+    await expect(`:cls=""`).toBeCssModule(``)
+    await expect(`:cls="[]"`).toBeCssModule(``)
+    await expect(`:cls="{}"`).toBeCssModule(``)
   })
-  test('单引号', () => {
-    expect(`cls='red yellow green'`).toBeCssModule(
+  test('单引号', async () => {
+    await expect(`cls='red yellow green'`).toBeCssModule(
       `:class='[$style["red"], $style["yellow"], $style["green"]]'`
     )
   })
-  test('混合引号', () => {
-    expect(`class="white" cls='red yellow green'`).toBeCssModule(
+  test('混合引号', async () => {
+    await expect(`class="white" cls='red yellow green'`).toBeCssModule(
       `class="white" :class='[$style["red"],$style["yellow"],$style["green"]]'`
     )
-    expect(`:class='["red"]' cls="red yellow green"`).toBeCssModule(
+    await expect(`:class='["red"]' cls="red yellow green"`).toBeCssModule(
       `:class='["red", $style["red"], $style["yellow"], $style["green"]]'`
     )
   })
-  test('非格式化', () => {
-    expect(`cls=" red  yellow   green     "`).toBeCssModule(
+  test('非格式化', async () => {
+    await expect(`cls=" red  yellow   green     "`).toBeCssModule(
       `:class="[$style['red'], $style['yellow'], $style['green']]"`
     )
   })
-  test('v-bind', () => {
-    expect(`:class="[type]" :cls="[type]"`).toBeCssModule(`:class="[type, $style[type]]"`)
-    expect(`:class="[type]" v-bind:cls="[type]"`).toBeCssModule(`:class="[type, $style[type]]"`)
-    expect(`v-bind:class="[type]" :cls="[type]"`).toBeCssModule(`:class="[type, $style[type]]"`)
-    expect(`v-bind:class="[type]" v-bind:cls="[type]"`).toBeCssModule(
+  test('v-bind', async () => {
+    await expect(`:class="[type]" :cls="[type]"`).toBeCssModule(`:class="[type, $style[type]]"`)
+    await expect(`:class="[type]" v-bind:cls="[type]"`).toBeCssModule(`:class="[type, $style[type]]"`)
+    await expect(`v-bind:class="[type]" :cls="[type]"`).toBeCssModule(`:class="[type, $style[type]]"`)
+    await expect(`v-bind:class="[type]" v-bind:cls="[type]"`).toBeCssModule(
       `:class="[type, $style[type]]"`
     )
   })
-  test('简写对象{item}', () => {
-    expect(`:class="[type]" :cls="{item}"`).toBeCssModule(
+  test('简写对象{item}', async () => {
+    await expect(`:class="[type]" :cls="{item}"`).toBeCssModule(
       `:class="{[type]: type, [$style['item']]: item}"`
     )
-    expect(`:class="[type]" :cls="{item, type: true}"`).toBeCssModule(
+    await expect(`:class="[type]" :cls="{item, type: true}"`).toBeCssModule(
       `:class="{[type]:type, [$style['item']]: item, [$style['type']]: true}"`
     )
   })
-  test('字符串中含,{}[]这类字符', () => {
-    expect(`:cls="type === ',[],{}'"`).toBeCssModule(`:class="[$style[type === ',[],{}']]"`)
-    expect(`:cls="{active: type === ',[],}{,}{', red: true}"`).toBeCssModule(
+  test('字符串中含,{}[]这类字符', async () => {
+    await expect(`:cls="type === ',[],{}'"`).toBeCssModule(`:class="[$style[type === ',[],{}']]"`)
+    await expect(`:cls="{active: type === ',[],}{,}{', red: true}"`).toBeCssModule(
       `:class="{ [$style['active']]: type === ',[],}{,}{', [$style['red']]: true}"`
     )
-    expect(`:cls="[ type === ',][],}{,}{' && 'green', 'red']"`).toBeCssModule(
+    await expect(`:cls="[ type === ',][],}{,}{' && 'green', 'red']"`).toBeCssModule(
       `:class="[ $style[type === ',][],}{,}{' && 'green' ], $style['red']]"`
     )
   })

--- a/test/string-array.spec.ts
+++ b/test/string-array.spec.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from 'vitest'
 
 describe('cls字符串，class数组', () => {
-  test('表达式1', () => {
-    expect(`:class="[]" cls="wrap"`).toBeCssModule(`:class="[$style['wrap']]"`)
+  test('表达式1', async () => {
+    await expect(`:class="[]" cls="wrap"`).toBeCssModule(`:class="[$style['wrap']]"`)
   })
-  test('表达式2', () => {
-    expect(`:class="['type', type]" cls=" green "`).toBeCssModule(
+  test('表达式2', async () => {
+    await expect(`:class="['type', type]" cls=" green "`).toBeCssModule(
       `:class="['type', type, $style['green']]"`
     )
   })

--- a/test/string-expression.spec.ts
+++ b/test/string-expression.spec.ts
@@ -1,22 +1,22 @@
 import { describe, expect, test } from 'vitest'
 
 describe('cls字符串，class表达式', () => {
-  test('表达式1', () => {
-    expect(`:class="type" cls="wrap"`).toBeCssModule(`:class="[type, $style['wrap']]"`)
+  test('表达式1', async () => {
+    await expect(`:class="type" cls="wrap"`).toBeCssModule(`:class="[type, $style['wrap']]"`)
   })
-  test('表达式2', () => {
-    expect(
+  test('表达式2', async () => {
+    await expect(
       `:class=" type === '1' ? type + '--active' : \`\${type + '--inactive'}\` " cls=" green "`
     ).toBeCssModule(
       `:class="[ type === '1' ? type + '--active' : \`\${type+'--inactive'}\`, $style['green']]"`
     )
   })
-  test('表达式3', () => {
-    expect(`:class="type === '1' && 'active'" cls="wrap"`).toBeCssModule(
+  test('表达式3', async () => {
+    await expect(`:class="type === '1' && 'active'" cls="wrap"`).toBeCssModule(
       `:class="[type === '1' && 'active', $style['wrap']]"`
     )
   })
-  test('表达式4', () => {
-    expect(`:class="'active'" cls="wrap"`).toBeCssModule(`:class="['active', $style['wrap']]"`)
+  test('表达式4', async () => {
+    await expect(`:class="'active'" cls="wrap"`).toBeCssModule(`:class="['active', $style['wrap']]"`)
   })
 })

--- a/test/string-none.spec.ts
+++ b/test/string-none.spec.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from 'vitest'
 
 describe('cls字符串，class空', () => {
-  test('单个', () => {
-    expect(`cls="wrap"`).toBeCssModule(`:class="[$style['wrap']]"`)
+  test('单个', async () => {
+    await expect(`cls="wrap"`).toBeCssModule(`:class="[$style['wrap']]"`)
   })
-  test('多个', () => {
-    expect(`cls="red yellow green"`).toBeCssModule(
+  test('多个', async () => {
+    await expect(`cls="red yellow green"`).toBeCssModule(
       `:class="[$style['red'], $style['yellow'], $style['green']]"`
     )
   })

--- a/test/string-object.spec.ts
+++ b/test/string-object.spec.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from 'vitest'
 
 describe('cls字符串，class对象', () => {
-  test('表达式1', () => {
-    expect(`:class="{}" cls="wrap"`).toBeCssModule(`:class="{[$style['wrap']]: true}"`)
+  test('表达式1', async () => {
+    await expect(`:class="{}" cls="wrap"`).toBeCssModule(`:class="{[$style['wrap']]: true}"`)
   })
-  test('表达式2', () => {
-    expect(`:class="{ type: type === 'add', [type]: true, }" cls=" green "`).toBeCssModule(
+  test('表达式2', async () => {
+    await expect(`:class="{ type: type === 'add', [type]: true, }" cls=" green "`).toBeCssModule(
       `:class="{ type: type === 'add', [type]:true, [$style['green']]: true}"`
     )
   })

--- a/test/string-string.spec.ts
+++ b/test/string-string.spec.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from 'vitest'
 
 describe('cls字符串，class字符串', () => {
-  test('单个', () => {
-    expect(`class="wrap" cls="wrap"`).toBeCssModule(`class="wrap" :class="[$style['wrap']]"`)
+  test('单个', async () => {
+    await expect(`class="wrap" cls="wrap"`).toBeCssModule(`class="wrap" :class="[$style['wrap']]"`)
   })
-  test('多个', () => {
-    expect(`class="red yellow" cls="green red"`).toBeCssModule(
+  test('多个', async () => {
+    await expect(`class="red yellow" cls="green red"`).toBeCssModule(
       `class="red yellow":class="[$style['green'], $style['red']]"`
     )
   })

--- a/vitest.d.ts
+++ b/vitest.d.ts
@@ -1,8 +1,8 @@
 import type { Assertion, AsymmetricMatchersContaining } from 'vitest'
 
 interface CustomMatchers<R = unknown> {
-  toBeCssModule(string): R
-  toBePugCssModule(string): R
+  toBeCssModule(string): Promise<R>
+  toBePugCssModule(string): Promise<R>
 }
 
 declare module 'vitest' {


### PR DESCRIPTION
Use `await` when calling custom tests matchers. Fix #14.