### PR TITLE
Fix package.json exports order, remove obsolete fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,13 +4,11 @@
   "description": "css-module syntactic sugar for vue3",
   "type": "module",
   "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.cjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.cjs"
     }
   },
   "files": [


### PR DESCRIPTION
`package.json` exports are currently incorrect:
- It has legacy undocumented `"module"` and `"types"` fields, which have never been standardized and are now obsolete/superseded with `"exports"`.
- The `"exports"` section doesn't put types at first position, [which is required](https://nodejs.org/api/packages.html#package-entry-points): _`"types"` - can be used by typing systems to resolve the typing file for the given export. **This condition should always be included first.**_

Running `vitest` emits the respective warnings:

```
▲ [WARNING] The condition "types" here will never be used as it comes after both "import" and "require" [package.json]

    package.json:13:6:
      13 │       "types": "./dist/index.d.ts"
         ╵       ~~~~~~~

  The "import" condition comes earlier and will be used for all "import" statements:

    package.json:11:6:
      11 │       "import": "./dist/index.js",
         ╵       ~~~~~~~~

  The "require" condition comes earlier and will be used for all "require" calls:

    package.json:12:6:
      12 │       "require": "./dist/index.cjs",
         ╵       ~~~~~~~~~
```

The PR fixes the exports section according to standards.