### PR TITLE
Support Vite 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,6 @@
     "cls",
     "vue3",
     "vite",
-    "vite4",
-    "vite5",
     "pug"
   ],
   "author": "jinpengh <13143352767@163.com>",
@@ -71,7 +69,7 @@
   },
   "peerDependencies": {
     "@vue/compiler-core": "^3.4.6",
-    "vite": "^4 || ^5 || ^6",
+    "vite": "^4 || ^5 || ^6 || ^7",
     "vue": ">= 3.2.13"
   },
   "optionalDependencies": {


### PR DESCRIPTION
With Nuxt 4 / Vite 7 out, this module works, but needs patching. The PR allows Vite 7 as a peer dependency. (Also, it removes versioned vite keywords that barely serve any purpose - let me know you think this is a mistake to remove them).